### PR TITLE
Make entrypoint.sh idempotent

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ sed -i "s|dataModel: ''|dataModel: '$PEDSNET_DATAMODELS_URL'|g" /usr/share/nginx
 sed -i "s|dqa: ''|dqa: '$PEDSNET_DQA_URL'|g" /usr/share/nginx/html/index.html
 sed -i "s|etl: ''|etl: '$PEDSNET_ETL_URL'|g" /usr/share/nginx/html/index.html
 sed -i "s|root: ''|root: '$PEDSNET_ROOT'|g" /usr/share/nginx/html/index.html
-sed -i "s|href='|href='$PEDSNET_ROOT|g" /usr/share/nginx/html/index.html
-sed -i "s|src='|src='$PEDSNET_ROOT|g" /usr/share/nginx/html/index.html
+sed -i "\|href='$PEDSNET_ROOT|!s|href='|href='$PEDSNET_ROOT|g" /usr/share/nginx/html/index.html
+sed -i "\|src='$PEDSNET_ROOT|!s|src='|src='$PEDSNET_ROOT|g" /usr/share/nginx/html/index.html
 
 $@


### PR DESCRIPTION
Fix #18 by enhancing two sed commands so that if the replacement is
seen (i.e. the sed command has already operated on the file before),
then the substitution is not performed.
